### PR TITLE
Handles orientation change.

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,11 @@ var ModalBox = React.createClass({
   },
 
   getInitialState: function () {
-    var position = this.props.entry === 'top' ? -screen.height : screen.height;
+    var size = this.viewport ? {
+        width: this.viewport.width,
+        height: this.viewport.height
+      } : screen;
+    var position = this.props.entry === 'top' ? -size.height : size.height;
     return {
       position: new Animated.Value(position),
       backdropOpacity: new Animated.Value(0),
@@ -78,10 +82,10 @@ var ModalBox = React.createClass({
       isAnimateClose: false,
       isAnimateOpen: false,
       swipeToClose: false,
-      height: screen.height,
-      width: screen.width,
-      containerHeight: screen.height,
-      containerWidth: screen.width,
+      height: size.height,
+      width: size.width,
+      containerHeight: size.height,
+      containerWidth: size.width,
       isInitialized: false
     };
   },
@@ -92,6 +96,18 @@ var ModalBox = React.createClass({
   },
 
   componentWillReceiveProps: function(props) {
+    if (props.viewport) {
+      if (!this.viewport ||
+        this.viewport.width !== props.viewport.width ||
+        this.viewport.height !== props.viewport.height) {
+        this.viewport = props.viewport;
+        var existingPanHandlers = this.state.pan;
+        this.state = this.getInitialState();
+        if (existingPanHandlers) {
+          this.state.pan = existingPanHandlers;
+        }
+      }
+    }
     this.handleOpenning(props);
   },
 


### PR DESCRIPTION
An external "viewport" property is accepted to replace initial "screen" and force a reset of state.
The "viewport" prop is optional and stored on the instance, where not present code will execute as original relying on the initial screen size.
"viewport" should contain at least a { width, height } couple.
